### PR TITLE
Add `filters` to relaxations and general fixes

### DIFF
--- a/src/xtalpaint/aiida/data.py
+++ b/src/xtalpaint/aiida/data.py
@@ -102,8 +102,10 @@ class BatchedStructuresData(Data):
 
         self.base.attributes.set("keys", list(structures.keys()).copy())
         self.base.attributes.set("filename", "structures.extxyz")
-
+        print(f"Len of structures: {len(structures)}")
         ase_structures = self.structures_to_atoms(structures)
+        print(f"Len of ase_structures: {len(ase_structures)}")
+        print([s.info.get("key") for s in ase_structures])
 
         self._structures_to_file(ase_structures, "structures")
 

--- a/src/xtalpaint/aiida/data.py
+++ b/src/xtalpaint/aiida/data.py
@@ -102,10 +102,8 @@ class BatchedStructuresData(Data):
 
         self.base.attributes.set("keys", list(structures.keys()).copy())
         self.base.attributes.set("filename", "structures.extxyz")
-        print(f"Len of structures: {len(structures)}")
+
         ase_structures = self.structures_to_atoms(structures)
-        print(f"Len of ase_structures: {len(ase_structures)}")
-        print([s.info.get("key") for s in ase_structures])
 
         self._structures_to_file(ase_structures, "structures")
 

--- a/src/xtalpaint/aiida/tasks/tasks.py
+++ b/src/xtalpaint/aiida/tasks/tasks.py
@@ -45,6 +45,7 @@ def _generate_inpainting_candidates_task(
         element=element,
         num_samples=num_samples,
     )
+    # raise ValueError(f'Generated {len(candidates)} candidates., {candidates.keys()}')
     return {"candidates": BatchedStructures(candidates)}
 
 

--- a/src/xtalpaint/aiida/tasks/tasks.py
+++ b/src/xtalpaint/aiida/tasks/tasks.py
@@ -45,7 +45,7 @@ def _generate_inpainting_candidates_task(
         element=element,
         num_samples=num_samples,
     )
-    # raise ValueError(f'Generated {len(candidates)} candidates., {candidates.keys()}')
+
     return {"candidates": BatchedStructures(candidates)}
 
 

--- a/src/xtalpaint/inpainting/generate_candidates.py
+++ b/src/xtalpaint/inpainting/generate_candidates.py
@@ -1,5 +1,6 @@
 """Functions to generate inpainting candidates for crystal structures."""
 
+from copy import deepcopy
 from typing import Iterable
 
 import numpy as np
@@ -13,7 +14,6 @@ def _add_inpainting_sites(
     structure: Structure, n_sites: int, element: str
 ) -> Structure:
     """Add n_sites sites with the element to the structure."""
-    structure = structure.copy()
     for _ in range(n_sites):
         structure.append(element, np.full(3, fill_value=np.nan))
     return structure
@@ -137,7 +137,7 @@ def structure_to_inpainting_candidates(
 
     for i_sample in range(num_samples):
         for j in range(num_inpaint_sites[0], num_inpaint_sites[1] + 1):
-            s_removed = structure.copy()
+            s_removed = deepcopy(structure)
             if remove_existing_sites:
                 s_removed.remove_sites(
                     [
@@ -158,7 +158,6 @@ def structure_to_inpainting_candidates(
             s_removed.properties["material_id"] = label
 
             structures_sites_removed[label] = s_removed
-
     return structures_sites_removed
 
 
@@ -196,4 +195,5 @@ def generate_inpainting_candidates(
             )
         )
 
+    print(f"Generated {len(candidates)} candidates., {candidates.keys()}")
     return candidates

--- a/src/xtalpaint/inpainting/generate_candidates.py
+++ b/src/xtalpaint/inpainting/generate_candidates.py
@@ -14,6 +14,7 @@ def _add_inpainting_sites(
     structure: Structure, n_sites: int, element: str
 ) -> Structure:
     """Add n_sites sites with the element to the structure."""
+    structure = structure.copy()
     for _ in range(n_sites):
         structure.append(element, np.full(3, fill_value=np.nan))
     return structure

--- a/src/xtalpaint/inpainting/generate_candidates.py
+++ b/src/xtalpaint/inpainting/generate_candidates.py
@@ -195,5 +195,4 @@ def generate_inpainting_candidates(
             )
         )
 
-    print(f"Generated {len(candidates)} candidates., {candidates.keys()}")
     return candidates

--- a/src/xtalpaint/utils/relaxation_utils.py
+++ b/src/xtalpaint/utils/relaxation_utils.py
@@ -45,7 +45,7 @@ def relax_atoms_mattersim_batched(
     potential = Potential.from_checkpoint(
         device=device, load_path=load_path, load_training_state=False
     )
-    kwargs.pop("max_n_steps", None)  # Only introduced in v1.2.0 which is
+    # kwargs.pop("max_n_steps", None)  # Only introduced in v1.2.0 which is
     # currently incompatbible with mattergen
 
     batch_relaxer = BatchRelaxer(potential=potential, **kwargs)
@@ -66,10 +66,10 @@ def _relax_atoms_mlip(
     **kwargs,
 ) -> float:
     """Relax Atoms using specified MLIP and optimizer."""
-    if filter.lower() not in SUPPORTED_FILTERS:
-        raise ValueError(f"Filter `{filter}` not implemented yet.")
-
-    filter_cls = SUPPORTED_FILTERS.get(filter.lower())
+    if filter is not None:
+        if filter.lower() not in SUPPORTED_FILTERS:
+            raise ValueError(f"Filter `{filter}` not implemented yet.")
+        filter_cls = SUPPORTED_FILTERS.get(filter.lower())
 
     opt_cls = {"bfgs": BFGS, "fire": FIRE}.get(optimizer.lower())
     if opt_cls is None:

--- a/src/xtalpaint/utils/relaxation_utils.py
+++ b/src/xtalpaint/utils/relaxation_utils.py
@@ -45,7 +45,7 @@ def relax_atoms_mattersim_batched(
     potential = Potential.from_checkpoint(
         device=device, load_path=load_path, load_training_state=False
     )
-    # kwargs.pop("max_n_steps", None)  # Only introduced in v1.2.0 which is
+    kwargs.pop("max_n_steps", None)  # Only introduced in v1.2.0 which is
     # currently incompatbible with mattergen
 
     batch_relaxer = BatchRelaxer(potential=potential, **kwargs)

--- a/src/xtalpaint/utils/relaxation_utils.py
+++ b/src/xtalpaint/utils/relaxation_utils.py
@@ -76,9 +76,11 @@ def _relax_atoms_mlip(
         raise ValueError("Unsupported optimizer. Use bfgs or fire.")
 
     if filter is not None:
-        atoms = filter_cls(atoms)
+        opt_atoms = filter_cls(atoms)
+    else:
+        opt_atoms = atoms
 
-    opt = opt_cls(atoms)
+    opt = opt_cls(opt_atoms)
     opt.run(fmax=fmax, steps=steps)
 
     return atoms, float(atoms.get_potential_energy())

--- a/src/xtalpaint/utils/relaxation_utils.py
+++ b/src/xtalpaint/utils/relaxation_utils.py
@@ -10,9 +10,15 @@ import tqdm
 from ase import Atoms
 from ase.calculators.calculator import Calculator
 from ase.constraints import FixAtoms
+from ase.filters import ExpCellFilter, FrechetCellFilter
 from ase.optimize import BFGS, FIRE
 from pymatgen.core import Structure
 from pymatgen.io.ase import AseAtomsAdaptor
+
+SUPPORTED_FILTERS = {
+    "expcellfilter": ExpCellFilter,
+    "frechetcellfilter": FrechetCellFilter,
+}
 
 
 def relax_atoms_mattersim_batched(
@@ -60,12 +66,17 @@ def _relax_atoms_mlip(
     **kwargs,
 ) -> float:
     """Relax Atoms using specified MLIP and optimizer."""
-    if filter is not None:
-        raise NotImplementedError("Filter not implemented yet.")
+    if filter.lower() not in SUPPORTED_FILTERS:
+        raise ValueError(f"Filter `{filter}` not implemented yet.")
+
+    filter_cls = SUPPORTED_FILTERS.get(filter.lower())
 
     opt_cls = {"bfgs": BFGS, "fire": FIRE}.get(optimizer.lower())
     if opt_cls is None:
         raise ValueError("Unsupported optimizer. Use bfgs or fire.")
+
+    if filter is not None:
+        atoms = filter_cls(atoms)
 
     opt = opt_cls(atoms)
     opt.run(fmax=fmax, steps=steps)
@@ -297,6 +308,7 @@ def relax_structures(
                 mask=[atom.symbol not in elements_to_relax for atom in a]
             )
             a.set_constraint(c)
+        kwargs.pop("filter", None)
 
     (
         relaxed_atoms,

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -44,7 +44,7 @@ def perturbed_structure(simple_structure):
     """Create a slightly perturbed version of simple_structure."""
     structure = simple_structure.copy()
     for site in structure.sites:
-        site.frac_coords += np.random.normal(scale=0.1, size=3)
+        site.frac_coords += np.random.normal(scale=0.7, size=3)
         site.frac_coords = site.frac_coords % 1.0  # Ensure coordinates are within [0, 1)
 
     return structure

--- a/tests/test_generate_candidates.py
+++ b/tests/test_generate_candidates.py
@@ -65,9 +65,10 @@ class TestAddInpaintingSites:
     def test_does_not_modify_original(self, simple_structure):
         """Test that original structure is not modified."""
         original_len = len(simple_structure)
-        _add_inpainting_sites(simple_structure, 2, "Si")
+        new_strct = _add_inpainting_sites(simple_structure, 2, "Si")
 
         assert len(simple_structure) == original_len
+        assert len(new_strct) == original_len + 2
 
     def test_add_zero_sites(self, simple_structure):
         """Test adding zero sites."""

--- a/tests/test_relaxation_utils.py
+++ b/tests/test_relaxation_utils.py
@@ -96,7 +96,7 @@ class TestRelaxAtomsMlip:
 
     def test_filter_not_implemented(self, sample_atoms):
         """Test that filter parameter raises NotImplementedError."""
-        with pytest.raises(NotImplementedError, match="Filter not implemented"):
+        with pytest.raises(ValueError, match="Filter not implemented"):
             _relax_atoms_mlip(
                 atoms=sample_atoms,
                 fmax=0.1,

--- a/tests/test_relaxation_utils.py
+++ b/tests/test_relaxation_utils.py
@@ -96,7 +96,7 @@ class TestRelaxAtomsMlip:
 
     def test_filter_not_implemented(self, sample_atoms):
         """Test that filter parameter raises NotImplementedError."""
-        with pytest.raises(ValueError, match="Filter not implemented"):
+        with pytest.raises(ValueError, match="Filter `some_filter` not implemented yet."):
             _relax_atoms_mlip(
                 atoms=sample_atoms,
                 fmax=0.1,


### PR DESCRIPTION
Support `ase.filters`.

Moreover, there was a bug in the generation of inpainting candidates, due to shallow copies.