### PR TITLE
Fix wheel packaging to include xtalpaint subpackages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,9 +41,9 @@ docs = [
     "nbconvert>=7.16.6",
 ]
 
-[tool.setuptools]
-packages = ["xtalpaint"]
-package-dir = {"" = "src"}
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["xtalpaint*"]
 
 # Ruff configuration
 [tool.ruff]


### PR DESCRIPTION
The static `packages = ["xtalpaint"]` list only declared the top-level package, so setuptools built wheels containing `src/xtalpaint/*.py` and nothing else. Subpackages such as `xtalpaint.aiida` were silently omitted, breaking non-editable installs and the aiida.data entry points that reference `xtalpaint.aiida.data`. Editable installs masked this because they import straight from the source tree.

Replace the static list with automatic discovery via `[tool.setuptools.packages.find]`, which picks up all subpackages under `src/`. The `where` setting supersedes the previous `package-dir` mapping, so both are removed.